### PR TITLE
[windows-building] Add .gitattributes for our .sh build scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Shell scripts
+*.sh eol=lf


### PR DESCRIPTION
This ensures that our build sh scripts are LF for eol.