### PR TITLE
[windows-version] Shortcut version and SHA short on Windows

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,8 +3,13 @@
 REPO_ROOT			:= $(shell git rev-parse --show-top-level)
 PROJECT_ROOT		:= $(abspath $(dir $(MAKEFILE_LIST)))
 PKG					= github.com/buildbeaver/buildbeaver
-VERSION_INFO		= $(shell ../build/scripts/version-info.sh)
-GIT_SHA_SHORT		= $(shell ../build/scripts/version-info.sh sha-short)
+ifeq ($(OS),Windows_NT)
+	VERSION_INFO		= $(shell git describe --long --tags --always)
+	GIT_SHA_SHORT		= $(shell git rev-parse --short=12 HEAD)
+else
+	VERSION_INFO		= $(shell ../build/scripts/version-info.sh)
+	GIT_SHA_SHORT		= $(shell ../build/scripts/version-info.sh sha-short)
+endif
 VERSION_VAR			=-X $(PKG)/common/version.VERSION=$(VERSION_INFO) -X $(PKG)/common/version.GITCOMMIT=$(GIT_SHA_SHORT)
 GO_LDFLAGS			=-ldflags "$(VERSION_VAR)"
 


### PR DESCRIPTION
Provide a shortcut for Windows to gather the VERSION_INFO and GIT_SHA_SHORT values for bb-cli version info.