### PR TITLE
Provide option to skip cleanup.

### DIFF
--- a/backend/bb/cmd/bb/commands/cleanup/cleanup.go
+++ b/backend/bb/cmd/bb/commands/cleanup/cleanup.go
@@ -71,7 +71,7 @@ var cleanupRootCmd = &cobra.Command{
 		}
 		defer cleanup()
 
-		utils.CleanUpOldResources(bb)
+		utils.CleanUpOldResources(bb, true)
 
 		return nil
 	},

--- a/backend/bb/cmd/bb/commands/run/root.go
+++ b/backend/bb/cmd/bb/commands/run/root.go
@@ -34,13 +34,19 @@ func init() {
 		"f",
 		false,
 		"Force all jobs to re-run by ignoring fingerprints")
+	runRootCmd.PersistentFlags().BoolVar(
+		&runCmdConfig.skipCleanup,
+		"skip-cleanup",
+		false,
+		"Do not attempt to clean up resources (including docker containers and networks) left over from previous runs")
 	commands.RootCmd.AddCommand(runRootCmd)
 }
 
 var runCmdConfig = struct {
-	workDir string
-	verbose bool
-	force   bool
+	workDir     string
+	verbose     bool
+	force       bool
+	skipCleanup bool
 }{}
 
 var runRootCmd = &cobra.Command{
@@ -87,7 +93,9 @@ var runRootCmd = &cobra.Command{
 		}
 		defer cleanup()
 
-		utils.CleanUpOldResources(bb)
+		if !runCmdConfig.skipCleanup {
+			utils.CleanUpOldResources(bb, runCmdConfig.verbose)
+		}
 
 		err = bb.Backend.Start()
 		if err != nil {

--- a/backend/bb/cmd/bb/utils/command_utils.go
+++ b/backend/bb/cmd/bb/utils/command_utils.go
@@ -50,7 +50,7 @@ func HomeifyPath(path string) (string, error) {
 }
 
 // CleanUpOldResources cleans up containers and other resources left over from previous runs.
-func CleanUpOldResources(bb *app.App) {
+func CleanUpOldResources(bb *app.App, verbose bool) {
 	timeout := time.Second * 30
 
 	// Use a special non-standard prefix for Docker names for bb, so the CleanUp function doesn't try to clean up
@@ -63,7 +63,11 @@ func CleanUpOldResources(bb *app.App) {
 	err := executor.CleanUp(timeout)
 	if err != nil {
 		// Log and ignore errors during cleanup
-		fmt.Fprintf(os.Stdout, "Warning: errors during cleanup: %s\r\n", err.Error())
+		if verbose {
+			fmt.Fprintf(os.Stdout, "Warning: unable to clean up resources. Use --skip-cleanup flag to skip this check.\r\n%s\r\n", err.Error())
+		} else {
+			fmt.Fprintf(os.Stdout, "Warning: unable to clean up resources. Use --skip-cleanup flag to skip this check, or -v flag to see errors.\r\n")
+		}
 	}
 }
 


### PR DESCRIPTION
Output only a brief warning if can't clean up, with verbose option.